### PR TITLE
Support official .yaml extension for YAML files

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -18,7 +18,7 @@ const loadFiles = async (files) => {
       const extension = file.split(".").pop();
 
       try {
-        if (extension === "yml") {
+        if (extension === "yml" || extension == "yaml") {
           dataObject = YAML.parse(fileContent);
         } else {
           dataObject = JSON.parse(fileContent);


### PR DESCRIPTION
# Description

This trivial change enables support for the `.yaml` file extension, which is the official file extension for YAML [per the YAML FAQ](https://yaml.org/faq.html).

# Testing

No new tests added, but existing ones pass:

```shell
$ npm test
...
Test Suites: 9 passed, 9 total
Tests:       44 passed, 44 total
Snapshots:   0 total
Time:        1.604 s, estimated 2 s
Ran all test suites.
```