### PR TITLE
Add support for anyOf and allOf

### DIFF
--- a/gh-pages/support.md
+++ b/gh-pages/support.md
@@ -36,8 +36,8 @@ Coverage for [A Vocabulary for Applying Subschemas](https://json-schema.org/draf
 | `additionalItems`       | No        |
 | `additionalProperties`  | Yes       |
 | `oneOf`                 | Yes       |
-| `allOf`                 | No        |
-| `anyOf`                 | No        |
+| `allOf`                 | Yes       |
+| `anyOf`                 | Yes       |
 | `contains`              | Yes       |
 | `dependentSchemas`      | No        |
 | `else`                  | No        |

--- a/gh-pages/yml/ajv-2019/allof.yml
+++ b/gh-pages/yml/ajv-2019/allof.yml
@@ -1,0 +1,38 @@
+$id: allof.yml
+$schema: http://json-schema.org/draft-07/schema#
+title: All-of
+description: Example schema to demonstrate the use of the allOf keyword
+type: object
+examples:
+  - allOfExample:
+      propertyA: With a string value
+  - allOfExample:
+      propertyB: 123
+      propertyC: 456
+properties:
+  allOfExample:
+    title: All Of Example
+    description: Property that demonstrates allOf
+    type: object
+    allOf:
+      - title: allOfExample option 0 with a single property
+        properties:
+          propertyA:
+            type: string
+            title: Property A
+        required:
+          - propertyA
+      - title: allOfExample option 1 with two properties
+        properties:
+          propertyB:
+            type: integer
+            title: Property B
+          propertyC:
+            type: integer
+            title: Property C
+        required:
+          - propertyB
+          - propertyC
+additionalProperties: false
+required:
+  - allOfExample

--- a/gh-pages/yml/ajv-2019/anyof.yml
+++ b/gh-pages/yml/ajv-2019/anyof.yml
@@ -1,0 +1,38 @@
+$id: anyof.yml
+$schema: http://json-schema.org/draft-07/schema#
+title: Any-of
+description: Example schema to demonstrate the use of the anyOf keyword
+type: object
+examples:
+  - anyOfExample:
+      propertyA: With a string value
+  - anyOfExample:
+      propertyB: 123
+      propertyC: 456
+properties:
+  anyOfExample:
+    title: Any Of Example
+    description: Property that demonstrates anyOf
+    type: object
+    anyOf:
+      - title: anyOfExample option 0 with a single property
+        properties:
+          propertyA:
+            type: string
+            title: Property A
+        required:
+          - propertyA
+      - title: anyOfExample option 1 with two properties
+        properties:
+          propertyB:
+            type: integer
+            title: Property B
+          propertyC:
+            type: integer
+            title: Property C
+        required:
+          - propertyB
+          - propertyC
+additionalProperties: false
+required:
+  - anyOfExample

--- a/lib/merger.js
+++ b/lib/merger.js
@@ -52,13 +52,35 @@ const resolveRef = (
       mergedProperty.$ref = resolvedRef.$ref || ref;
     }
 
-    // @todo handle allOf, anyOf
+    // handle allOf, anyOf
     if (resolvedRef.oneOf) {
       resolvedRef.oneOf.forEach((oneItem, index) => {
         if (oneItem.$ref) {
           let mergedResolvedRef = pointer.get(mergedSchema, refPointer);
           if (mergedResolvedRef.oneOf && mergedResolvedRef.oneOf[index]) {
             mergedResolvedRef.oneOf[index].$ref = oneItem.$ref;
+          }
+        }
+      });
+    }
+
+    if (resolvedRef.allOf) {
+      resolvedRef.allOf.forEach((allItem, index) => {
+        if (allItem.$ref) {
+          let mergedResolvedRef = pointer.get(mergedSchema, refPointer);
+          if (mergedResolvedRef.allOf && mergedResolvedRef.allOf[index]) {
+            mergedResolvedRef.allOf[index].$ref = allItem.$ref;
+          }
+        }
+      });
+    }
+
+    if (resolvedRef.anyOf) {
+      resolvedRef.anyOf.forEach((anyItem, index) => {
+        if (anyItem.$ref) {
+          let mergedResolvedRef = pointer.get(mergedSchema, refPointer);
+          if (mergedResolvedRef.anyOf && mergedResolvedRef.anyOf[index]) {
+            mergedResolvedRef.anyOf[index].$ref = anyItem.$ref;
           }
         }
       });
@@ -127,12 +149,28 @@ Merger.mergeSchemas = function (unresolvedSchemas, resolvedSchemas) {
       }
     }
 
-    // @todo handle top-level oneOf, allOf, anyOf
+    // handle top-level oneOf, allOf, anyOf
     if (mergedSchema.data.oneOf) {
       mergedSchema.data.oneOf.forEach((one, index) => {
         // @todo this is going to throw exceptions
         mergedSchema.data.oneOf[index].$ref =
           unresolvedSchema.data.oneOf[index].$ref;
+      });
+    }
+
+    if (mergedSchema.data.allOf) {
+      mergedSchema.data.allOf.forEach((all, index) => {
+        // @todo this is going to throw exceptions
+        mergedSchema.data.allOf[index].$ref =
+          unresolvedSchema.data.allOf[index].$ref;
+      });
+    }
+
+    if (mergedSchema.data.anyOf) {
+      mergedSchema.data.anyOf.forEach((any, index) => {
+        // @todo this is going to throw exceptions
+        mergedSchema.data.anyOf[index].$ref =
+          unresolvedSchema.data.anyOf[index].$ref;
       });
     }
 

--- a/lib/renderer-markdown.js
+++ b/lib/renderer-markdown.js
@@ -108,6 +108,54 @@ const oneOfRow = (name, property) => {
   return html;
 };
 
+const allOfRow = (name, property) => {
+  const length = Object.keys(property.allOf).length;
+  let html =
+    `<tr><th rowspan="${length}">${name}</th>` +
+    `<td rowspan="${length}">All of:</td>`;
+  let isFirstRow = true;
+
+  for (const key in property.allOf) {
+    let allOfItem = property.allOf[key];
+
+    if (!isFirstRow) {
+      html += "<tr>";
+    }
+
+    html += `<td>${getLabelForProperty(
+      allOfItem.type ? allOfItem : property
+    )}</td></tr>`;
+
+    isFirstRow = false;
+  }
+
+  return html;
+};
+
+const anyOfRow = (name, property) => {
+  const length = Object.keys(property.anyOf).length;
+  let html =
+    `<tr><th rowspan="${length}">${name}</th>` +
+    `<td rowspan="${length}">Any of:</td>`;
+  let isFirstRow = true;
+
+  for (const key in property.anyOf) {
+    let anyOfItem = property.anyOf[key];
+
+    if (!isFirstRow) {
+      html += "<tr>";
+    }
+
+    html += `<td>${getLabelForProperty(
+      anyOfItem.type ? anyOfItem : property
+    )}</td></tr>`;
+
+    isFirstRow = false;
+  }
+
+  return html;
+};
+
 const oneOfArrayRow = (oneOf) => {
   const length = oneOf.length;
   let html = "";
@@ -121,6 +169,46 @@ const oneOfArrayRow = (oneOf) => {
     }
 
     html += `<th>${getLabelForProperty(one)}</th></tr>`;
+
+    isFirstRow = false;
+  });
+
+  return html;
+};
+
+const allOfArrayRow = (allOf) => {
+  const length = allOf.length;
+  let html = "";
+  let isFirstRow = true;
+
+  allOf.forEach((all) => {
+    if (isFirstRow) {
+      html += `<tr><th colspan="2" rowspan="${length}">All of:</th>`;
+    } else {
+      html += "<tr>";
+    }
+
+    html += `<th>${getLabelForProperty(all)}</th></tr>`;
+
+    isFirstRow = false;
+  });
+
+  return html;
+};
+
+const anyOfArrayRow = (anyOf) => {
+  const length = anyOf.length;
+  let html = "";
+  let isFirstRow = true;
+
+  anyOf.forEach((any) => {
+    if (isFirstRow) {
+      html += `<tr><th colspan="2" rowspan="${length}">Any of:</th>`;
+    } else {
+      html += "<tr>";
+    }
+
+    html += `<th>${getLabelForProperty(any)}</th></tr>`;
 
     isFirstRow = false;
   });
@@ -145,6 +233,18 @@ const propertiesTable = (schema, parentKey) => {
       (!property.$ref || property.$ref.match(/^#/))
     ) {
       html += oneOfRow(key, property);
+    } else if (
+      property &&
+      property.allOf != undefined &&
+      (!property.$ref || property.$ref.match(/^#/))
+    ) {
+      html += allOfRow(key, property);
+    } else if (
+      property &&
+      property.anyOf != undefined &&
+      (!property.$ref || property.$ref.match(/^#/))
+    ) {
+      html += anyOfRow(key, property);
     } else {
       html += propertyRow(key, property, parentKey);
     }
@@ -153,6 +253,16 @@ const propertiesTable = (schema, parentKey) => {
   let oneOf = schema.oneOf;
   if (Array.isArray(oneOf) && oneOf.length > 0) {
     html += oneOfArrayRow(oneOf);
+  }
+
+  let allOf = schema.allOf;
+  if (Array.isArray(allOf) && allOf.length > 0) {
+    html += allOfArrayRow(allOf);
+  }
+
+  let anyOf = schema.anyOf;
+  if (Array.isArray(anyOf) && anyOf.length > 0) {
+    html += anyOfArrayRow(anyOf);
   }
 
   html += "</tbody></table>";
@@ -181,6 +291,10 @@ Handlebars.registerHelper("propertyTypeRow", function (property) {
   let html;
   if (property.oneOf != undefined) {
     html = `<tr>${oneOfRow("Type", property)}</tr>`;
+  } else if (property.allOf != undefined) {
+    html = `<tr>${allOfRow("Type", property)}</tr>`;
+  } else if (property.anyOf != undefined) {
+    html = `<tr>${anyOfRow("Type", property)}</tr>`;
   } else {
     const typeLabel = getLabelForProperty(property);
     if (typeLabel) {

--- a/templates/schema.hbs
+++ b/templates/schema.hbs
@@ -104,6 +104,24 @@
 {{/if}}
 {{/each}}
 {{/if}}
+{{#if this.allOf }}
+{{#each this.allOf}}
+{{#if (isDefined ../parentKey)}}
+{{> property parentKey=(concat ../parentKey '.' ../propertyKey) propertyKey=@key }}
+{{else}}
+{{> property parentKey=../propertyKey propertyKey=@key }}
+{{/if}}
+{{/each}}
+{{/if}}
+{{#if this.anyOf }}
+{{#each this.anyOf}}
+{{#if (isDefined ../parentKey)}}
+{{> property parentKey=(concat ../parentKey '.' ../propertyKey) propertyKey=@key }}
+{{else}}
+{{> property parentKey=../propertyKey propertyKey=@key }}
+{{/if}}
+{{/each}}
+{{/if}}
 {{/unless}}
 
 {{/inline}}

--- a/tests/merger.test.js
+++ b/tests/merger.test.js
@@ -149,6 +149,106 @@ let resolvedSchemas3 = [
   },
 ];
 
+let unresolvedSchemas4 = [
+  {
+    filename: "schema/file5.json",
+    data: {
+      $id: 5,
+      title: "5 unresolved",
+      properties: { property1: { $ref: "#/definitions/property1" } },
+      definitions: {
+        property1: {
+          allOf: [{ $ref: "property1.json" }, { $ref: "property2.json" }],
+        },
+      },
+    },
+  },
+];
+let resolvedSchemas4 = [
+  {
+    filename: "schema/file5.json",
+    data: {
+      $id: 5,
+      title: "5 resolved",
+      properties: {
+        property1: {
+          allOf: [
+            {
+              title: "allOfProperty1",
+            },
+            {
+              title: "allOfProperty2",
+            },
+          ],
+        },
+      },
+      required: [],
+      definitions: {
+        property1: {
+          allOf: [
+            {
+              title: "allOfProperty1",
+            },
+            {
+              title: "allOfProperty2",
+            },
+          ],
+        },
+      },
+    },
+  },
+];
+
+let unresolvedSchemas5 = [
+  {
+    filename: "schema/file6.json",
+    data: {
+      $id: 6,
+      title: "6 unresolved",
+      properties: { property1: { $ref: "#/definitions/property1" } },
+      definitions: {
+        property1: {
+          anyOf: [{ $ref: "property1.json" }, { $ref: "property2.json" }],
+        },
+      },
+    },
+  },
+];
+let resolvedSchemas5 = [
+  {
+    filename: "schema/file6.json",
+    data: {
+      $id: 6,
+      title: "6 resolved",
+      properties: {
+        property1: {
+          anyOf: [
+            {
+              title: "anyOfProperty1",
+            },
+            {
+              title: "anyOfProperty2",
+            },
+          ],
+        },
+      },
+      required: [],
+      definitions: {
+        property1: {
+          anyOf: [
+            {
+              title: "anyOfProperty1",
+            },
+            {
+              title: "anyOfProperty2",
+            },
+          ],
+        },
+      },
+    },
+  },
+];
+
 test("merges schemas", () => {
   const results = Merger.mergeSchemas(unresolvedSchemas, resolvedSchemas);
   expect(results).toHaveLength(2);
@@ -173,6 +273,28 @@ test("sets $ref in definitions containing OneOf", () => {
   expect(property.oneOf.length).toBe(2);
   expect(property.oneOf[0].title).toBe("oneOfProperty1");
   expect(property.oneOf[1].title).toBe("oneOfProperty2");
+});
+
+test("sets $ref in definitions containing AllOf", () => {
+  const results = Merger.mergeSchemas(unresolvedSchemas4, resolvedSchemas4);
+  expect(results).toHaveLength(1);
+  expect(results[0].filename).toBe("schema/file5.json");
+  expect(results[0].schema.$id).toBe(5);
+  let property = results[0].schema.properties.property1;
+  expect(property.allOf.length).toBe(2);
+  expect(property.allOf[0].title).toBe("allOfProperty1");
+  expect(property.allOf[1].title).toBe("allOfProperty2");
+});
+
+test("sets $ref in definitions containing AnyOf", () => {
+  const results = Merger.mergeSchemas(unresolvedSchemas5, resolvedSchemas5);
+  expect(results).toHaveLength(1);
+  expect(results[0].filename).toBe("schema/file6.json");
+  expect(results[0].schema.$id).toBe(6);
+  let property = results[0].schema.properties.property1;
+  expect(property.anyOf.length).toBe(2);
+  expect(property.anyOf[0].title).toBe("anyOfProperty1");
+  expect(property.anyOf[1].title).toBe("anyOfProperty2");
 });
 
 test("XXX sets isRequired on each schama property", () => {

--- a/tests/renderer-markdown.test.js
+++ b/tests/renderer-markdown.test.js
@@ -90,6 +90,36 @@ let defaultMergedSchema = {
           },
         },
       },
+      property6: {
+        title: "Property 6",
+        type: "object",
+        isRequired: true,
+        allOf: [
+          {
+            title: "AllOf Property 1",
+            type: "string",
+          },
+          {
+            title: "AllOf Property 2",
+            type: "integer",
+          },
+        ],
+      },
+      property7: {
+        title: "Property 7",
+        type: "object",
+        isRequired: true,
+        anyOf: [
+          {
+            title: "AnyOf Property 1",
+            type: "string",
+          },
+          {
+            title: "AnyOf Property 2",
+            type: "integer",
+          },
+        ],
+      },
     },
   },
 };
@@ -149,6 +179,8 @@ test("renders attributes", async () => {
     '<tr><td colspan="2"><a href="#property3">property3</a></td><td>Array [<a href="property3.html">property3.html</a>]</td></tr>' +
     '<tr><td colspan="2"><a href="#property4">property4</a></td><td>String</td></tr>' +
     '<tr><td colspan="2"><a href="#property5">property5</a></td><td>Object</td></tr>' +
+    '<tr><td colspan="2"><a href="#property6">property6</a></td><td>All of:</td></tr>' +
+    '<tr><td colspan="2"><a href="#property7">property7</a></td><td>Any of:</td></tr>' +
     "</tbody></table>";
 
   expect(result).toContain(expectedText);


### PR DESCRIPTION
Related to #134

Add support for JSON Schema `allOf` and `anyOf` keywords.

* Modify `lib/merger.js` to handle `allOf` and `anyOf` keywords in the `resolveRef` and `mergeSchemas` functions.
* Modify `lib/renderer-markdown.js` to add functions for rendering `allOf` and `anyOf` rows and update the `propertiesTable` function.
* Modify `templates/schema.hbs` to include handling for `allOf` and `anyOf` keywords.
* Update `gh-pages/support.md` to indicate that `allOf` and `anyOf` are supported keywords.
* Add example schemas `gh-pages/yml/ajv-2019/allof.yml` and `gh-pages/yml/ajv-2019/anyof.yml` demonstrating the use of `allOf` and `anyOf` keywords.
* Modify `tests/merger.test.js` to add test cases for `allOf` and `anyOf` keywords in the `mergeSchemas` function.
* Modify `tests/renderer-markdown.test.js` to add test cases for rendering `allOf` and `anyOf` rows.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tomcollins/json-schema-static-docs/issues/134?shareId=XXXX-XXXX-XXXX-XXXX).