### PR TITLE
Fixes for Windows

### DIFF
--- a/lib/json-schema-static-docs.js
+++ b/lib/json-schema-static-docs.js
@@ -39,13 +39,13 @@ JsonSchemaStaticDocs.prototype.generate = async function () {
   const inputPathPattern = fastGlob.convertPathToPattern(
     this._options.inputPath
   );
-  const inputPathGlob = path.join(
+  const inputPathGlob = path.posix.join(
     inputPathPattern,
     this._options.inputFileGlob
   );
 
   // clean up path (strip leading ./ etc)
-  const cleanInputPath = path.join(this._options.inputPath);
+  const cleanInputPath = path.posix.join(this._options.inputPath);
 
   const unresolvedSchemas = await Loader.loadFiles(inputPathGlob);
   console.log(

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -1,13 +1,13 @@
 const fs = require('fs');
-const makeDir = require('make-dir');
+const path = require('path');
 
 var Writer = function(){}
 
 Writer.writeFile = async function(filename, data) {
-  let parts = filename.split('/');
+  let parts = filename.split(path.sep);
   let dirName = parts.splice(0, parts.length-1).join('/');
-  if (!fs.existsSync(dirName)) {
-    await makeDir(dirName);
+  if (dirName && !fs.existsSync(dirName)) {
+    fs.mkdirSync(dirName, {recursive:true})
   }
   fs.writeFileSync(filename, data);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.28.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^10.1.0",
+        "@apidevtools/json-schema-ref-parser": "^12.0.2",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "extend": "^3.0.2",
@@ -47,15 +47,14 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-10.1.0.tgz",
-      "integrity": "sha512-3e+viyMuXdrcK8v5pvP+SDoAQ77FH6OyRmuK48SZKmdHJRFm87RsSs8qm6kP39a/pOPURByJw+OXzQIqcfmKtA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-12.0.2.tgz",
+      "integrity": "sha512-SoZWqQz4YMKdw4kEMfG5w6QAy+rntjsoAT1FtvZAnVEnCR4uy9YSuDBNoVAFHgzSz0dJbISLLCSrGR2Zd7bcvA==",
+      "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.11",
-        "@types/lodash.clonedeep": "^4.5.7",
-        "js-yaml": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0"
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1307,22 +1306,10 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.197",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.197.tgz",
-      "integrity": "sha512-BMVOiWs0uNxHVlHBgzTIqJYmj+PgCo4euloGF+5m4okL3rEYzM2EEv78mw8zWSMM57dM7kVIgJ2QDvwHSoCI5g=="
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
-      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.5.6",
@@ -3200,11 +3187,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^10.1.0",
+    "@apidevtools/json-schema-ref-parser": "^12.0.2",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "extend": "^3.0.2",


### PR DESCRIPTION
Allows running this lib on Windows! :)

> `"@apidevtools/json-schema-ref-parser": "^12.0.2",`

Since v11, they support Windows, and it seems all tests pass with the latest version, so why not?